### PR TITLE
Dont check for setup file in docker script, do so in the common script

### DIFF
--- a/ci/jenkins/build_workspace
+++ b/ci/jenkins/build_workspace
@@ -37,7 +37,7 @@ chmod 0755 $MERGE_BACK_SCRIPT
 
 export POST_CLONE_HOOK=$MERGE_BACK_SCRIPT
 
-./index/setup/setup_workspace
+./index/setup/setup_workspace -i
 
 unset POST_CLONE_HOOK
 

--- a/setup/generate_setup_script
+++ b/setup/generate_setup_script
@@ -25,7 +25,7 @@ WORKSPACE_SCRIPT=$WORKSPACE_PATH/bringup
 WORKSPACE_RCFILE=$WORKSPACE_PATH/.bashrc
 
 echo ">>> Checking if $WORKSPACE_PATH is empty or doesnt exists to build the workspace there"
-if [ ! -d "$WORKSPACE_PATH" ] || [ -z "$(ls -A "$WORKSPACE_PATH" | grep -v 'setup')" ]; then
+if [ ! -d "$WORKSPACE_PATH" ] || [ "$(ls -A "$WORKSPACE_PATH" | wc -l)" -eq 0 ]; then
     echo ">>>> Creating directory"
     mkdir -p $WORKSPACE_PATH
 else
@@ -154,9 +154,30 @@ SETUP_SCRIPT_TEMPLATE = """\
 set -eu
 set -o pipefail
 
+IGNORE_DIRECTORY_CONTENT=0
+while getopts "i" opt
+   do
+     case $opt in
+        i)
+        IGNORE_DIRECTORY_CONTENT=1
+        shift;;
+     esac
+done
+
 WORKSPACE_PATH=$(realpath ${1:-$(pwd)})
 WORKSPACE_SCRIPT=$WORKSPACE_PATH/bringup
 WORKSPACE_RCFILE=$WORKSPACE_PATH/.bashrc
+
+# This script can be called by docker if used, and if that happens, a setup file is generated.
+
+echo ">>> Checking if $WORKSPACE_PATH is empty or doesnt exists to build the workspace there"
+if [ ! -d "$WORKSPACE_PATH" ] || [ -z "$(ls -A "$WORKSPACE_PATH" | grep -v 'setup')" ] || [ "$IGNORE_DIRECTORY_CONTENT" -eq 1 ]; then
+    echo ">>>> Creating directory"
+    mkdir -p $WORKSPACE_PATH
+else
+    echo ">>>> Directory is not empty. Not going to build the workspace"
+    exit 1
+fi
 
 echo ">>> Installing base dependencies..."
 

--- a/setup/setup_workspace
+++ b/setup/setup_workspace
@@ -5,4 +5,4 @@ INDEX_PATH=$(realpath $SCRIPT_PATH/..)
 
 $SCRIPT_PATH/generate_setup_script --with-stable-ignition \
     --with-drake-nightly $INDEX_PATH/drake.repos \
-    --repos $INDEX_PATH/maliput.repos | bash -s $@
+    --repos $INDEX_PATH/maliput.repos | bash -s -- $@


### PR DESCRIPTION
The script was checking if a file was not present in the beginning of the docker script, which didn't make any sense so now we check for a complete empty directory. Since the docker script creates the setup file before it ends, we have to check for the setup file in **SETUP_SCRIPT_TEMPLATE** since the docker script runs it too