### PR TITLE
Updates Setup Script Name and Generalizes documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Introduction
-The `dsim_workspace` development environment integrates numerous driving
-simulation packages including Delphyne, Drake, Malidrive, and Maliput. This
-repository contains .repo indices, Makefiles, and scripts, that enable the
-creation and maintenance of a `dsim_workspace`.
+This repository contains .repos files that facilitate the creation of various
+workspaces. Each workspace is targeted for a different use case. For example,
+`malidrive.repos` is used to create a `maliput_workspace`, which enables Maliput
+and Malidrive development.
 
 ## Setup
 
-See [here](setup/README.md) for setup and usage instructions.
+See [here](setup/README.md) for workspace setup and usage instructions.

--- a/ci/jenkins/build_workspace
+++ b/ci/jenkins/build_workspace
@@ -37,7 +37,7 @@ chmod 0755 $MERGE_BACK_SCRIPT
 
 export POST_CLONE_HOOK=$MERGE_BACK_SCRIPT
 
-./index/setup/setup_workspace -f
+./index/setup/setup_maliput_workspace -f
 
 unset POST_CLONE_HOOK
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,4 +1,7 @@
-# Setup
+# General Setup
+
+This section contains instructions on how to setup your development environment
+to support workspaces.
 
 ## Supported platforms
 
@@ -31,18 +34,24 @@ sudo apt install pciutils
   repository. Instructions can be found
   [at this helpful post](https://gist.github.com/Brainiarc7/a8ab5f89494d053003454efc3be2d2ef).
 
-## Basic Setup
+# Workspace Setup
 
-To setup a regular workspace, run:
+There are many workspaces that can be setup. The sections below focus on
+`maliput_workspace`. The same general steps can be follow for creating other
+types of workspaces.
+
+## Basic Setup of `maliput_workspace`
+
+To setup a regular `maliput_workspace`, run:
 
 ```sh
-dsim-repos-index/setup/setup_workspace dsim_workspace
+dsim-repos-index/setup/setup_maliput_workspace maliput_workspace
 ```
 
-To setup a dockerized workspace, run:
+To setup a dockerized `maliput_workspace`, run:
 
 ```sh
-dsim-repos-index/setup/setup_dockerized_workspace dsim_workspace
+dsim-repos-index/setup/setup_dockerized_maliput_workspace maliput_workspace
 ```
 
 Note: The docker image will be called maliput-devel:<unix_timestamp>. We decided
@@ -56,10 +65,10 @@ upstream dependencies whenever possible.
 
 ## Bringup
 
-To bring up any of these workspaces, run:
+To bring up the workspace, run:
 
 ```sh
-source dsim_workspace/bringup
+source maliput_workspace/bringup
 ```
 
 You can always leave the workspace by `exit`ing it.
@@ -74,7 +83,7 @@ most commonly used ones.
 You can check all available workspace options by running:
 
 ```sh
-dsim-repos-index/setup/generate_setup_script -h
+dsim-repos-index/setup/generate_maliput_setup_script -h
 ```
 
 The output of this script is pure bash code that can be verified, modified and
@@ -108,7 +117,8 @@ source install/setup.bash
 
 ## How to Build and Run Tests
 
-At the moment, tests are built by default, so once colcon finishes building, you can run:
+At the moment, tests are built by default, so once colcon finishes building, you
+can run:
 
 ```sh
 colcon test --event-handlers=console_direct+ --return-code-on-test-failure --packages-skip PROJ4
@@ -122,7 +132,7 @@ To update your workspace:
 2. Run
 
 ```sh
-cd dsim_workspace
+cd maliput_workspace
 source bringup -u [dsim-repos-index]
 ```
 
@@ -130,11 +140,13 @@ Note: You need to provide the **full path to the dsim-repos-index repository**
 to the -u option. This will **increase your docker image size** because it will
 commit the image with the new changes. Also, we **don't recommend you to update
 your workspace using this command** if you decided to customize your setup
-instead of using **setup_dockerized_workspace** or **setup_workspace**
+instead of using **setup_dockerized_maliiput_workspace** or
+**setup_maliput_workspace**.
 
 ## How to Check Drake Version
 
-After entering your workspace, building it, and executing `source ./install/setup.bash`, execute:
+After entering your `maliput_workspace`, building it, and executing
+`source ./install/setup.bash`, execute:
 
 ```
 which-drake
@@ -142,7 +154,7 @@ which-drake
 
 ## How to Update Drake
 
-To update Drake within your workspace:
+To update Drake within your `maliput_workspace`:
 
 1. Select a Drake SHA that you would like to use. Ensure it is the last commit
    of a nightly release, see

--- a/setup/generate_maliput_setup_script
+++ b/setup/generate_maliput_setup_script
@@ -175,7 +175,7 @@ docker run --privileged --rm --net=host \\\\
     -idt $IMAGE_NAME /bin/bash --rcfile $WORKSPACE_RCFILE
 
 DSIM_PATH="\$(realpath -s \$DSIM_PATH)"
-\$DSIM_PATH/setup/generate_setup_script --with-stable-ignition \
+\$DSIM_PATH/setup/generate_maliput_setup_script --with-stable-ignition \
   --with-drake-nightly \$DSIM_PATH/drake.repos \
   --repos \$DSIM_PATH/maliput.repos -o /tmp/setup
 
@@ -404,7 +404,7 @@ shift \$((OPTIND-1))
 if [ ! -z \$DSIM_PATH ]; then
 DSIM_PATH="\$(realpath -s \$DSIM_PATH)"
 echo ">>> Updating workspace"
-\$DSIM_PATH/setup/setup_workspace $WORKSPACE_PATH
+\$DSIM_PATH/setup/setup_maliput_workspace $WORKSPACE_PATH
 unset DSIM_PATH
 echo ">>> You can source bringup now"
 else

--- a/setup/setup_dockerized_maliput_workspace
+++ b/setup/setup_dockerized_maliput_workspace
@@ -4,7 +4,7 @@ SCRIPT_PATH=$(dirname $(realpath $0))
 INDEX_PATH=$(realpath $SCRIPT_PATH/..)
 SETUP_PATH=$(mktemp /tmp/setup.XXXXXX)
 
-$SCRIPT_PATH/generate_setup_script --inside-docker maliput-devel \
+$SCRIPT_PATH/generate_maliput_setup_script --inside-docker maliput-devel \
     --with-drake-nightly $INDEX_PATH/drake.repos --with-stable-ignition \
     --repos $INDEX_PATH/maliput.repos -o $SETUP_PATH
 

--- a/setup/setup_maliput_workspace
+++ b/setup/setup_maliput_workspace
@@ -3,6 +3,6 @@
 SCRIPT_PATH=$(dirname $(realpath $0))
 INDEX_PATH=$(realpath $SCRIPT_PATH/..)
 
-$SCRIPT_PATH/generate_setup_script --with-stable-ignition \
+$SCRIPT_PATH/generate_maliput_setup_script --with-stable-ignition \
     --with-drake-nightly $INDEX_PATH/drake.repos \
     --repos $INDEX_PATH/maliput.repos | bash -s -- $@


### PR DESCRIPTION
There isn't going to be a single all-encompassing `dsim-workspace`.
Instead, this repo enables the creation of many different workspaces,
each focused on a different set of tasks.

The original "setup_workspace" and "setup_dockerized_workspace" scripts
had misleading names since they create workspaces for Maliput and Malidrive
development. I added "maliput" to their names to clarify this confusion.