### PR TITLE
Print repo status after merging in CI

### DIFF
--- a/ci/jenkins/build_workspace
+++ b/ci/jenkins/build_workspace
@@ -31,6 +31,7 @@ if [ ! -z "$CHANGE_BRANCH" ]; then
        echo $DIFF
        exit 1
     fi
+    vcs status src
 fi
 EOF
 chmod 0755 $MERGE_BACK_SCRIPT


### PR DESCRIPTION
Precisely what the title says. CI's been working suspiciously for the past few weeks and I'd like to get better insight. The patch is, for the most part, innocuous.