### PR TITLE
Adds sudo to prereqs-install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ create a smaller workspace with `maliput` and `malidrive` packages only.
 
   ```sh
   cd dsim-repos-index
-  ./tools/prereqs-install .
+  sudo ./tools/prereqs-install .
   ```
 
   To install `nvidia-docker`, also run:
 
   ```sh
   cd dsim-repos-index
-  ./tools/prereqs-install -t nvidia .
+  sudo ./tools/prereqs-install -t nvidia .
   ```
 
 ## Usage instructions


### PR DESCRIPTION
Otherwise, we run into:

$ ./tools/prereqs-install -t nvidia .
┌ Checking configuration...
│  Tags:  nvidia
│  Interactive:  no
└ Ready for installation
• Installing prerequisites at  /home/liang/dev/dsim-repos-index/prereqs
│  ==========================  Captured stderr  ==========================
│  The dsim index prerequisites script must run as root. Please use sudo.
└─ ✗ Exited with non-zero exit code:  1