### PR TITLE
Add links to development repositories (and their READMEs).

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,11 +317,11 @@ standard ROS2's development workflow**, and therefore their usage and extension 
 The following is an exhaustive list of the repositories where all relevant packages live, excluding
 repositories for upstream dependencies:
 
-- [ToyotaResearchInstitute/delphyne](https://github.com/ToyotaResearchInstitute/delphyne/)
-- [ToyotaResearchInstitute/delphyne-gui](https://github.com/ToyotaResearchInstitute/delphyne-gui/)
-- [ToyotaResearchInstitute/drake-ros](https://github.com/ToyotaResearchInstitute/drake-ros/)
-- [ToyotaResearchInstitute/malidrive](https://github.com/ToyotaResearchInstitute/malidrive/)
-- [ToyotaResearchInstitute/maliput](https://github.com/ToyotaResearchInstitute/maliput/)
+- [ToyotaResearchInstitute/delphyne](https://github.com/ToyotaResearchInstitute/delphyne/), that contains a package with the back-end for a traffic level simulator for autonomous driving.
+- [ToyotaResearchInstitute/delphyne-gui](https://github.com/ToyotaResearchInstitute/delphyne-gui/), that contains a package with the front-end for a traffic level simulator for autonomous driving.
+- [ToyotaResearchInstitute/drake-ros](https://github.com/ToyotaResearchInstitute/drake-ros/), that contains a vendoring package for [`drake`](https://github.com/RobotLocomotion/drake).
+- [ToyotaResearchInstitute/malidrive](https://github.com/ToyotaResearchInstitute/malidrive/), that contains a package with a `maliput` backend for the OpenDrive specification.
+- [ToyotaResearchInstitute/maliput](https://github.com/ToyotaResearchInstitute/maliput/), that contains packages introducing `maliput`, a road network runtime interface, and reference backends: `dragway` and `multilane`.
 
 ## How to use CI
 


### PR DESCRIPTION
Precisely what the title says. Partially addresses #46 (only https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/46#issuecomment-500889375).