### PR TITLE
Fix timerTriggered() check in Jenkinsfile.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ node('delphyne-linux-bionic-unprovisioned') {
 def timeTriggered() {
   def causes = currentBuild.getBuildCauses()
   for (cause in causes) {
-    if (cause.class.toString().contains('TimerTrigger')) {
+    if (cause._class.toString().contains('TimerTrigger')) {
       return true;
     }
   }


### PR DESCRIPTION
Precisely what the title says. This is currently preventing the tarballs from being generated (as the pipeline can't tell when it's running a nightly job).