### PR TITLE
Add 'bounce' command to reset workspace shell env without leaving it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,6 @@ cd maliput_ws
 source bringup
 ```
 
-In certain cases e.g. after installing packages, you may want to reset the workspace shell
-environment as if you had just brought it up. To do so, run:
-
-```sh
-bounce
-```
-
 You can always leave the workspace by `exit`ing it.
 
 Note
@@ -109,6 +102,16 @@ Note
    should be saved. For the sake of storage efficiency, only save them if you've applied changes
    outside the workspace directory and to the container filesystem itself (e.g. you installed a
    new package or tool using `apt`) and you wish to keep them.
+
+In certain cases e.g. after installing packages, you may want to reset the workspace shell
+environment as if you had just brought it up. To do so, from within the workspace run:
+
+```sh
+bounce
+```
+
+Note
+:  Bouncing a workspace **will not save it**. To save, you must exit the workspace.
 
 ### Update your workspace
 

--- a/tools/wsetup
+++ b/tools/wsetup
@@ -224,7 +224,7 @@ source ~/.bashrc
 # Let the user know this is another environment.
 export PS1="(@{ workspace_name }@ env) \\${PS1:-}"
 
-# Add workspace deletion command.
+# Add command to delete the workspace.
 function nuke() {
   read -p 'Do you want to delete this workspace? [y/N]: ' answer
   if [[ "\\${answer:0:1}" =~ y|Y ]]; then
@@ -238,7 +238,9 @@ function nuke() {
   fi
 }
 
-# Add workspace environment reset command.
+# Add command to reset the workspace shell environment, as if the user had
+# exited and re-entered it (or teared it down and brought it up, thus the
+# name).
 function bounce() {
   exec /bin/bash --rcfile \\${BASH_SOURCE[0]} -i
 }


### PR DESCRIPTION
Closes #68. The newly added `bounce` command has the same effect that re-entering the workspace has when it comes to the shell environment. Then, setting up a workspace from scratch (not including workspace building) gets reduced to:

```sh
dsim-repos-index/tools/wsetup maliput_ws
cp dsim-repos-index/maliput.repos maliput_ws/
cd maliput_ws
source bringup
mkdir -p src
vcs import src < maliput.repos
vcs pull src  # not necessary on first creation
sudo prereqs-install -t all src
bounce
rosdep update
rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport5 ignition-msgs2 ignition-math5 ignition-common2 ignition-gui0 ignition-rendering0 libqt5multimedia5 pybind11 PROJ4" --from-paths src
exit
y
```