### PR TITLE
Add ign-plugin repository to repos file to build ignition from source

### DIFF
--- a/ignition.repos
+++ b/ignition.repos
@@ -8,3 +8,4 @@ repositories:
   ign_transport   : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-transport.git',     version: 'ign-transport5' }
   ign_rendering   : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-rendering.git',     version: 'ign-rendering2' }
   ign_gui         : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-gui.git',           version: 'ign-gui0' }
+  ign_plugin      : { type: 'hg',  url: 'https://bitbucket.org/ignitionrobotics/ign-plugin.git',        version: 'ign-plugin1' }


### PR DESCRIPTION
One of the ignition packages was missing to build from source