### PR TITLE
Add ament_cmake to workspace default prereqs.

### DIFF
--- a/tools/etc/default.prereqs
+++ b/tools/etc/default.prereqs
@@ -8,6 +8,13 @@ prereqs.init 'The default prerequisites of any DSim workspace'
 
 prereqs.assert_sudo
 
+declare -A DISTRO_MAP
+DISTRO_MAP[bionic]=dashing
+DISTRO_MAP[xenial]=bouncy
+DISTRO=${DISTRO_MAP[$(lsb_release -sc)]}
+
+ASSERT_MSG="Unknown ROS distro, maybe not on an Ubuntu box?" prereqs.assert [ ! -z "$DISTRO" ]
+
 prereqs.install_apt_repo "ros2-latest" "http://packages.ros.org/ros2/ubuntu" "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654"
 
 prereqs.apt update
@@ -24,7 +31,15 @@ prereqs.apt install \
             python3-vcstool \
             python3-rosdep \
             python3-colcon-common-extensions \
+            ros-$DISTRO-ament-cmake \
             tmux
+
+if ! grep -q "^source /opt/ros/$DISTRO/setup.bash" ~/.bashrc; then
+    cat >> ~/.bashrc <<< "source /opt/ros/$DISTRO/setup.bash"
+fi
+if ! grep -q "^export ROS_DISTRO=" ~/.bashrc; then
+    cat >> ~/.bashrc <<< "export ROS_DISTRO=$DISTRO"
+fi
 
 rosdep init || true
 


### PR DESCRIPTION
Precisely what the title says, no need to duplicate this in packages.