### PR TITLE
Add Doxygen documentation indexing tool.

### DIFF
--- a/dsim.repos
+++ b/dsim.repos
@@ -1,8 +1,9 @@
 repositories:
   ament_cmake_doxygen : { type: 'git', url: 'https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen.git',  version: 'master' }
-  maliput             : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/maliput.git',              version: 'master' }
-  delphyne            : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',             version: 'master' }
-  delphyne_gui        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',         version: 'master' }
-  drake_vendor        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/drake-vendor.git',         version: 'master' }
-  malidrive           : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/malidrive.git',            version: 'master' }
-  proj4               : { type: 'git', url: 'https://github.com/OSGeo/proj.4.git',                             version: '5.2.0'  }
+  maliput             : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/maliput.git',                  version: 'master' }
+  delphyne            : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',                 version: 'master' }
+  delphyne_gui        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',             version: 'master' }
+  drake_vendor        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/drake-vendor.git',             version: 'master' }
+  dsim-docs           : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/dsim-docs.git',                version: 'master' }
+  malidrive           : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/malidrive.git',                version: 'master' }
+  proj4               : { type: 'git', url: 'https://github.com/OSGeo/proj.4.git',                                 version: '5.2.0'  }


### PR DESCRIPTION
This pull request adds a tool to help aggregate multiple Doxygen generate HTML sites. It relies on the infrastructure first introduced by https://github.com/ToyotaResearchInstitute/malidrive/pull/314 and https://github.com/ToyotaResearchInstitute/maliput/pull/165.

-----

To test this out:

1. Import these repositories using `vcs`.

```yaml
repositories:
  ament_cmake_doxygen : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/ament_cmake_doxygen.git',  version: 'master' }
  maliput             : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/maliput.git',              version: 'hidmic/doxygen' }
  delphyne            : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',             version: 'master' }
  delphyne_gui        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',         version: 'master' }
  drake_vendor        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/drake-vendor.git',         version: 'master' }
  malidrive           : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/malidrive.git',            version: 'hidmic/doxygen' }
  proj4               : { type: 'git', url: 'https://github.com/OSGeo/proj.4.git',                             version: '5.2.0'  }
``` 

2. Build up to `malidrive` including documentation but in a separate, common location:
```sh
colcon build --packages-up-to malidrive --cmake-args -DBUILD_DOCS=1 -DDOXYGEN_BUILD_ROOT=`pwd`/doc
```
3. Generate the index site at `doc`:

```sh
cd doc/
/path/to/dsim-docs-index DSim-Index
```
4. Build the index site:

```sh
doxygen
```

5. Browse the resulting HTML site.

In an upcoming PR, nightly jobs will use this tool to deploy a single documentation site.