### PR TITLE
Adds pybind11 to the repository list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ applies.
 
    ```sh
    rosdep update
-   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport5 ignition-msgs2 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 libqt5multimedia5 PROJ4" --from-paths src
+   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport5 ignition-msgs2 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 libqt5multimedia5 PROJ4 pybind11" --from-paths src
    ```
 
    Warning

--- a/ci/jenkins/install_deps
+++ b/ci/jenkins/install_deps
@@ -4,4 +4,4 @@ set -eo pipefail
 
 rosdep update
 
-sudo rosdep install -i -y --rosdistro=$ROS_DISTRO --skip-keys="ignition-transport5 ignition-msgs2 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 libqt5multimedia5 PROJ4" --from-paths src
+sudo rosdep install -i -y --rosdistro=$ROS_DISTRO --skip-keys="ignition-transport5 ignition-msgs2 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 libqt5multimedia5 PROJ4 pybind11" --from-paths src

--- a/dsim.repos
+++ b/dsim.repos
@@ -7,3 +7,4 @@ repositories:
   dsim_docs_bundler   : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/dsim-docs-bundler.git',        version: 'master' }
   malidrive           : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/malidrive.git',                version: 'master' }
   proj4               : { type: 'git', url: 'https://github.com/OSGeo/proj.4.git',                                 version: '5.2.0'  }
+  pybind11            : { type: 'git', url: 'https://github.com/RobotLocomotion/pybind11.git',                     version: '69a5d92a5ff9fe84581a1edeb6051a8c21d9eb97'  }


### PR DESCRIPTION
> Related to [maliput#284](https://github.com/ToyotaResearchInstitute/maliput/issues/284)

- The[ `pybind11` repository from `RobotLocomotion` ](https://github.com/RobotLocomotion/pybind11)was added to `dsim-repos` file to be available in the workspace. 

The version of `pybind11` matches with the version of `pybind11` that `drake` brings by `drake_vendor`.

- The rosdep install command was modified in CI and int the README.