### PR TITLE
Adds maliput-integration repository to dsim.repos file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ repositories for upstream dependencies:
 - [ToyotaResearchInstitute/drake-vendor](https://github.com/ToyotaResearchInstitute/drake-vendor/), that contains a vendoring package for [`drake`](https://github.com/RobotLocomotion/drake).
 - [ToyotaResearchInstitute/malidrive](https://github.com/ToyotaResearchInstitute/malidrive/), that contains a package with a `maliput` backend for the OpenDrive specification.
 - [ToyotaResearchInstitute/maliput](https://github.com/ToyotaResearchInstitute/maliput/), that contains packages introducing `maliput`, a road network runtime interface, and reference backends: `dragway` and `multilane`.
+- [ToyotaResearchInstitute/maliput-integration](https://github.com/ToyotaResearchInstitute/maliput-integration/), that contains integration examples and tools that unify `maliput` core and its possible backends.
 
 ## How to use CI
 

--- a/dsim.repos
+++ b/dsim.repos
@@ -1,6 +1,7 @@
 repositories:
   ament_cmake_doxygen : { type: 'git', url: 'https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen.git',  version: 'master' }
   maliput             : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/maliput.git',                  version: 'master' }
+  maliput_integration : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/maliput-integration.git',      version: 'master' }
   delphyne            : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne.git',                 version: 'master' }
   delphyne_gui        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/delphyne-gui.git',             version: 'master' }
   drake_vendor        : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/drake-vendor.git',             version: 'master' }


### PR DESCRIPTION
This is part of splitting `maliput` into multiple repositories.
See [maliput#278](https://github.com/ToyotaResearchInstitute/maliput/issues/278)