### PR TITLE
Enables clang-8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,13 @@ Note
 that `CMAKE_BUILD_TYPE=Debug`. You can force it by passing `--cmake-args -DCMAKE_BUILD_TYPE=Debug`
 to `colcon`.
 
+Note
+:  If you want to build with `clang`, run the following:
+
+   ```sh
+   CC=clang CXX=clang++ colcon build --packages-up-to maliput malidrive
+   ```
+
 3. Source the workspace:
 
    ```sh

--- a/tools/etc/default.prereqs
+++ b/tools/etc/default.prereqs
@@ -4,6 +4,58 @@ set -e pipefail
 
 source prereqs.lib
 
+#######################################
+# Installs clang suite packages.
+# Arguments:
+#   Version of the clang suite package.
+# Returns:
+#   0 if no error was detected, non-zero otherwise.
+#######################################
+function install_clang_suite() {
+  local version=$1
+
+  prereqs.apt install \
+              clang-${version} \
+              lldb-${version} \
+              lld-${version} \
+              clang-format-${version} \
+              clang-tidy-${version} \
+              libc++-${version}-dev \
+              libc++abi-${version}-dev
+}
+
+#######################################
+# Setups alternatives for clang suite.
+# Arguments:
+#   Version of the clang suite package.
+# Returns:
+#   0 if no error was detected, 2 otherwise.
+#######################################
+function update_clang_suite_alternatives() {
+  local version=$1
+  local priority=$2
+
+  update-alternatives \
+    --install /usr/bin/clang                 clang                 /usr/bin/clang-${version}  ${priority}\
+    --slave   /usr/bin/clang++               clang++               /usr/bin/clang++-${version}  \
+    --slave   /usr/bin/asan_symbolize        asan_symbolize        /usr/bin/asan_symbolize-${version} \
+    --slave   /usr/bin/c-index-test          c-index-test          /usr/bin/c-index-test-${version} \
+    --slave   /usr/bin/clang-check           clang-check           /usr/bin/clang-check-${version} \
+    --slave   /usr/bin/clang-cl              clang-cl              /usr/bin/clang-cl-${version} \
+    --slave   /usr/bin/clang-cpp             clang-cpp             /usr/bin/clang-cpp-${version} \
+    --slave   /usr/bin/clang-format          clang-format          /usr/bin/clang-format-${version} \
+    --slave   /usr/bin/clang-format-diff     clang-format-diff     /usr/bin/clang-format-diff-${version} \
+    --slave   /usr/bin/clang-import-test     clang-import-test     /usr/bin/clang-import-test-${version} \
+    --slave   /usr/bin/clang-include-fixer   clang-include-fixer   /usr/bin/clang-include-fixer-${version} \
+    --slave   /usr/bin/clang-offload-bundler clang-offload-bundler /usr/bin/clang-offload-bundler-${version} \
+    --slave   /usr/bin/clang-query           clang-query           /usr/bin/clang-query-${version} \
+    --slave   /usr/bin/clang-rename          clang-rename          /usr/bin/clang-rename-${version} \
+    --slave   /usr/bin/clang-reorder-fields  clang-reorder-fields  /usr/bin/clang-reorder-fields-${version} \
+    --slave   /usr/bin/clang-tidy            clang-tidy            /usr/bin/clang-tidy-${version} \
+    --slave   /usr/bin/lldb                  lldb                  /usr/bin/lldb-${version} \
+    --slave   /usr/bin/lldb-server           lldb-server           /usr/bin/lldb-server-${version}
+}
+
 prereqs.init 'The default prerequisites of any DSim workspace'
 
 prereqs.assert_sudo
@@ -14,6 +66,9 @@ DISTRO_MAP[xenial]=bouncy
 DISTRO=${DISTRO_MAP[$(lsb_release -sc)]}
 
 ASSERT_MSG="Unknown ROS distro, maybe not on an Ubuntu box?" prereqs.assert [ ! -z "$DISTRO" ]
+
+CLANG_SUITE_VERSION=8
+CLANG_SUITE_ALTERNATIVE_PRIORITY=10
 
 prereqs.install_apt_repo "ros2-latest" "http://packages.ros.org/ros2/ubuntu" "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654"
 
@@ -33,6 +88,10 @@ prereqs.apt install \
             python3-colcon-common-extensions \
             ros-$DISTRO-ament-cmake \
             tmux
+
+install_clang_suite ${CLANG_SUITE_VERSION}
+update_clang_suite_alternatives ${CLANG_SUITE_VERSION} ${CLANG_SUITE_ALTERNATIVE_PRIORITY}
+
 
 if ! grep -q "^source /opt/ros/$DISTRO/setup.bash" ~/.bashrc; then
     cat >> ~/.bashrc <<< "source /opt/ros/$DISTRO/setup.bash"


### PR DESCRIPTION
Provides `clang-8` to maliput_ws and explains how to build with it in README.

Relates to #64 