### PR TITLE
Modifies run_scan_build.py script.

### DIFF
--- a/tools/run_scan_build.py
+++ b/tools/run_scan_build.py
@@ -83,8 +83,10 @@ def generate_exclude_args(argv):
 
   exclusion_paths = set()
   for package in packages_to_get_exclude_file_of:
-    stream = os.popen('find src/' + package + ' -name scan_build.supp')
-    supp_filepaths = stream.read().splitlines()
+    package_path = os.popen('colcon list --packages-select ' + package + ' --paths-only')
+    command = 'find ' + package_path.read().splitlines()[0] + ' -name scan_build.supp'
+    find = os.popen(command)
+    supp_filepaths = find.read().splitlines()
     for filepath in supp_filepaths:
       get_exclusion_paths_from_file(filepath, exclusion_paths)
   return convert_in_exclude_argument(exclusion_paths)


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/malidrive/pull/660

Malidirive's files are reorganized.

`run_scan_build.py` script must change when collecting the suppression paths for the `scan-build`.