### PR TITLE
Add scan build

### DIFF
--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron:  '0 9 * * *' # 9:00am UTC, 1:00am PST.
+    - cron:  '0 9 * * 1' # 9:00am UTC, 1:00am PST every Monday.
 
 env:
   PACKAGE_NAME: dsim-repos-index


### PR DESCRIPTION
Goes on top of #148 

Part of https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/136

Adds scan  build to Github Actions CI.