### PR TITLE
Clean up scan_build workflow

### DIFF
--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -10,25 +10,11 @@ env:
   ROS_WS: maliput_ws
 
 jobs:
-  compile_and_test:
-    name: Compile and test
+  static_analysis:
+    name: Static analysis
     runs-on: ubuntu-18.04
     container:
       image: ubuntu:18.04
-    strategy:
-      matrix:
-        sanitizer: [none, asan, ubsan]
-        include:
-          - sanitizer: none
-            COMPILER_FLAG: ''
-          - sanitizer: asan
-            COMPILER_FLAG: ' -DADDRESS_SANITIZER=On'
-          - sanitizer: ubsan
-            COMPILER_FLAG: ' -DUNDEFINED_SANITIZER=On'
-    env:
-      CC: clang
-      CXX: clang++
-      LINKER_PATH: /usr/bin/llvm-ld
     steps:
     # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
     - uses: ros-tooling/setup-ros@0.0.26


### PR DESCRIPTION
This removes some settings copied from the sanitizers workflow and updates the display name to match the configuration of other packages.