### PR TITLE
Pairs the rosdep install call between build and scan_build workflows.

### DIFF
--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -133,7 +133,7 @@ jobs:
       run: |
         rosdep update;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "ignition-transport5 ignition-msgs2 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 libqt5multimedia5 pybind11" \
+          --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 libqt5multimedia5 pybind11" \
           --from-paths src
     - name: scan_build
       shell: bash


### PR DESCRIPTION
See https://github.com/ToyotaResearchInstitute/dsim-repos-index/runs/1587964772?check_suite_focus=true

It failed because of old rosdep install calls. This PR fixes the scan_build job.