### PR TITLE
Use ignition citadel dependencies

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -6,7 +6,7 @@ repositories:
   ign-gui0:
     type: git
     url: https://github.com/scpeters/ign-gui
-    version: gui0_blueprint
+    version: gui0_citadel
   pybind11:
     type: git
     url: https://github.com/RobotLocomotion/pybind11.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
       run: |
         rosdep update;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 pybind11" \
+          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" \
           --from-paths src
     - name: colcon build libraries
       shell: bash

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -148,7 +148,7 @@ jobs:
       run: |
         rosdep update;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 pybind11" \
+          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" \
           --from-paths src
     - name: colcon build libraries
       shell: bash

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -135,7 +135,7 @@ jobs:
       run: |
         rosdep update;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 pybind11" \
+          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" \
           --from-paths src
     - name: scan_build
       shell: bash

--- a/.github/workflows/workspace_build.yml
+++ b/.github/workflows/workspace_build.yml
@@ -113,7 +113,7 @@ jobs:
       run: |
         rosdep update;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} \
-          --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 libqt5multimedia5 pybind11" \
+          --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" \
           --from-paths src
     - name: install drake via drake_vendor
       shell: bash

--- a/DEPRECATED_README.md
+++ b/DEPRECATED_README.md
@@ -210,7 +210,7 @@ applies.
 
    ```sh
    rosdep update
-   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 pybind11" --from-paths src
+   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" --from-paths src
    ```
 
    Warning
@@ -261,7 +261,7 @@ necessary to build and execute. And we can easily inspect repositories.
 4. To see if (most of) our versioned packages' dependencies have been met, run:
 
    ```sh
-   rosdep check --rosdistro $ROS_DISTRO --skip-keys "ignition-transport7 ignition-msgs4 ignition-math5 ignition-common2 ignition-gui0 ignition-rendering0 pybind11" --from-paths src
+   rosdep check --rosdistro $ROS_DISTRO --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" --from-paths src
    ```
 
    Note though that currently not all workspace prerequisites are nor can be dealt with using `rosdep`
@@ -501,7 +501,7 @@ your intended purpose.
 
    ```sh
    rosdep update
-   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 pybind11" --from-paths /opt/dsim-desktop/*
+   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" --from-paths /opt/dsim-desktop/*
    ```
 
 6. When exiting the workspace, make sure changes are saved!

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ and satisfy their dependencies.
    Install dependencies via `rosdep`:
    ```sh
    rosdep update
-   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 pybind11" --from-paths src
+   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" --from-paths src
    ```
 
    Warning
@@ -144,13 +144,13 @@ and satisfy their dependencies.
       sudo apt -y install --no-install-recommends \
                       libignition-common3-dev \
                       libignition-math6-dev \
-                      libignition-msgs4-dev \
+                      libignition-msgs5-dev \
                       libignition-tools-dev \
                       libignition-cmake1-dev \
                       libignition-cmake2-dev \
-                      libignition-rendering2-dev \
-                      libignition-gui2-dev \
-                      libignition-transport7-dev
+                      libignition-rendering3-dev \
+                      libignition-gui3-dev \
+                      libignition-transport8-dev
     ```
 
 6. #### Install drake:
@@ -242,7 +242,7 @@ necessary to build and execute. And we can easily inspect repositories.
 3. To see if (most of) our versioned packages' dependencies have been met, run:
 
    ```sh
-   rosdep check --rosdistro $ROS_DISTRO --skip-keys "ignition-transport7 ignition-msgs4 ignition-math5 ignition-common2 ignition-gui0 ignition-rendering0 pybind11" --from-paths src
+   rosdep check --rosdistro $ROS_DISTRO --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" --from-paths src
    ```
 
    Note though that currently not all workspace prerequisites are nor can be dealt with using `rosdep`
@@ -469,7 +469,7 @@ your intended purpose.
    ```sh
    export ROS_DISTRO=dashing
    rosdep update
-   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport7 ignition-msgs4 ignition-math6 ignition-common3 ignition-gui0 ignition-rendering2 pybind11" --from-paths /opt/dsim-desktop/*
+   rosdep install -i -y --rosdistro $ROS_DISTRO --skip-keys "ignition-transport8 ignition-msgs5 ignition-math6 ignition-common3 ignition-gui0 ignition-gui3 ignition-rendering3 pybind11" --from-paths /opt/dsim-desktop/*
    ```
 
 5. Install drake.
@@ -490,13 +490,13 @@ your intended purpose.
     sudo apt -y install --no-install-recommends \
                     libignition-common3-dev \
                     libignition-math6-dev \
-                    libignition-msgs4-dev \
+                    libignition-msgs5-dev \
                     libignition-tools-dev \
                     libignition-cmake2-dev \
                     libignition-cmake1-dev \
-                    libignition-rendering2-dev \
-                    libignition-gui2-dev \
-                    libignition-transport7-dev
+                    libignition-rendering3-dev \
+                    libignition-gui3-dev \
+                    libignition-transport8-dev
    ```
 
 From then on, before building the workspace, you must source the underlay as follows:

--- a/dsim.repos
+++ b/dsim.repos
@@ -13,4 +13,4 @@ repositories:
   dsim_docs_bundler         : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/dsim-docs-bundler.git',         version: 'master' }
   malidrive                 : { type: 'git', url: 'git@github.com:ToyotaResearchInstitute/malidrive.git',                 version: 'master' }
   pybind11                  : { type: 'git', url: 'https://github.com/RobotLocomotion/pybind11.git',                      version: '69a5d92a5ff9fe84581a1edeb6051a8c21d9eb97'  }
-  ign-gui0                  : { type: 'git', url: 'https://github.com/scpeters/ign-gui', version: 'gui0_blueprint' }
+  ign-gui0                  : { type: 'git', url: 'https://github.com/scpeters/ign-gui', version: 'gui0_citadel' }

--- a/ignition.repos
+++ b/ignition.repos
@@ -4,8 +4,9 @@ repositories:
   ign_tools       : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-tools.git',         version: 'ign-tools0' }
   ign_math        : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-math.git',          version: 'ign-math6' }
   ign_common      : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-common.git',        version: 'ign-common3' }
-  ign_msgs        : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-msgs.git',          version: 'ign-msgs4' }
-  ign_transport   : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-transport.git',     version: 'ign-transport7' }
-  ign_rendering   : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-rendering.git',     version: 'ign-rendering2' }
-  ign_gui0        : { type: 'git',  url: 'https://github.com/scpeters/ign-gui.git',                   version: 'gui0_blueprint' }
+  ign_msgs        : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-msgs.git',          version: 'ign-msgs5' }
+  ign_transport   : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-transport.git',     version: 'ign-transport8' }
+  ign_rendering   : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-rendering.git',     version: 'ign-rendering3' }
+  ign_gui0        : { type: 'git',  url: 'https://github.com/scpeters/ign-gui.git',                   version: 'gui0_citadel' }
+  ign_gui3        : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-gui.git',           version: 'ign-gui3' }
   ign_plugin      : { type: 'git',  url: 'https://github.com/ignitionrobotics/ign-plugin.git',        version: 'ign-plugin1' }


### PR DESCRIPTION
This migrates the workspace to use dependencies from the ignition-citadel collection, which is an [LTS release](https://ignitionrobotics.org/docs/all/releases#release-list). Also, point to a custom branch of ign-gui0 that uses ign-msgs5, ign-transport8, and ign-rendering3 until we are ready to switch fully to ign-gui3.

Part of https://github.com/ToyotaResearchInstitute/delphyne-gui/issues/332, requires ToyotaResearchInstitute/delphyne#768 and https://github.com/ToyotaResearchInstitute/delphyne-gui/pull/360