### PR TITLE
install_dependencies: add foxy to ROS_DISTRO_MAP

### DIFF
--- a/tools/install_dependencies.sh
+++ b/tools/install_dependencies.sh
@@ -79,6 +79,7 @@ function install_clang_suite() {
 
 # Get correspondant ROS DISTRO.
 declare -A ROS_DISTRO_MAP
+ROS_DISTRO_MAP[focal]=foxy
 ROS_DISTRO_MAP[bionic]=dashing
 ROS_DISTRO_MAP[xenial]=bouncy
 ROS_DISTRO=${ROS_DISTRO_MAP[$(lsb_release -sc)]}


### PR DESCRIPTION
The `install_dependencies.sh` script currently fails on focal, since it doesn't know which `ROS_DISTRO` to use. I'm not changing the distro in the Dockerfiles yet, but this is a necessary step in order to make a 20.04 workspace.

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196