### PR TITLE
Modifies run.sh to fix bug when creating a container.

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -72,7 +72,7 @@ WORKSPACE_CONTAINER=/home/$(whoami)/$WORKSPACE_FOLDER/
 SSH_AUTH_SOCK_USER=$SSH_AUTH_SOCK
 
 # Check if name container is already taken.
-if sudo -g docker docker container ls -a | grep "${CONTAINER_NAME}$" -c &> /dev/null; then
+if sudo -g docker docker container ls -a | grep -w "${CONTAINER_NAME}$" -c &> /dev/null; then
    printf "Error: Docker container called $CONTAINER_NAME is already opened.     \
    \n\nTry removing the old container by doing: \n\t docker rm $CONTAINER_NAME   \
    \nor just initialize it with a different name.\n"


### PR DESCRIPTION

```diff
- if sudo -g docker docker container ls -a | grep "${CONTAINER_NAME}$" -c &> /dev/null; then
+ if sudo -g docker docker container ls -a | grep -w "${CONTAINER_NAME}$" -c &> /dev/null; then
```

Without this change, the script doesn't let you run the container because the container name is included in other containers' names despite not being exactly the same.
e.g: `maliput_ws_foxy` is an already created container image and if you attempt to create `maliput_ws` it wouldn't let you.
