### PR TITLE
Uploads scan-build results as GH artifacts in failure.

### DIFF
--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -141,3 +141,10 @@ jobs:
         . /opt/ros/${ROS_DISTRO}/setup.bash;
         ${GITHUB_WORKSPACE}/${PACKAGE_NAME}/tools/run_scan_build.py \
           --event-handlers=console_direct+;
+    # upload artifact
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: scan-build-output
+        path: /tmp/scan-build*/*
+        retention-days: 6


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53065142/144073237-064e7eeb-2872-46ab-b9cc-2d485cfb74af.png)
