### PR TITLE
Fixes exit trap.

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright 2021 Toyota Research Institute
 
-set -e
+set +e
 
 # Prints information about usage.
 function show_help() {


### PR DESCRIPTION
Solves #186 

The trapped function wasn't being executed when doing `exit` (check that doing `exit 0` would work correctly) within the container when the last $? value was different than zero.

setting `set +e` instead of `-e` solves the problem as when doing `exit` the default value being passed is zero instead of $?.

