### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains basic workspace infrastructure for dsim repositories.
 ## Where is my README?
 
 As part of [#182](https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/182),
-the README was migrated to [maliput_documentation](https://github.com/ToyotaResearchInstitute/maliput_documentation/blob/main/docs/installation_quickstart.rst).
+the README was migrated to [maliput_documentation](https://github.com/maliput/maliput_documentation/blob/main/docs/developer_setup.rst).
 
 ## Where is my old and deprecated README?
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes broken link in readme

## Summary

The documentation page linked in the README was renamed in https://github.com/maliput/maliput_documentation/pull/99, so update the link accordingly.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
