### PR TITLE
Adds maliput_sparse and maliput_osm dependencies to the maliput.repos file and CI builds.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -13,5 +13,7 @@ repositories:
   maliput_malidrive         : { type: 'git', url: 'https://github.com/maliput/maliput_malidrive.git',                     version: 'main' }
   maliput_py                : { type: 'git', url: 'https://github.com/maliput/maliput_py.git',                            version: 'main' }
   maliput_dragway           : { type: 'git', url: 'https://github.com/maliput/maliput_dragway.git',                       version: 'main' }
+  maliput_sparse            : { type: 'git', url: 'https://github.com/maliput/maliput_sparse.git',                        version: 'main' }
+  maliput_osm               : { type: 'git', url: 'https://github.com/maliput/maliput_osm.git',                           version: 'main' }
   maliput_multilane         : { type: 'git', url: 'https://github.com/maliput/maliput_multilane.git',                     version: 'main' }
   maliput_documentation     : { type: 'git', url: 'https://github.com/maliput/maliput_documentation.git',                 version: 'main' }

--- a/repos_index/foxy/maliput.repos
+++ b/repos_index/foxy/maliput.repos
@@ -10,3 +10,5 @@ repositories:
   maliput_py                : { type: 'git', url: 'https://github.com/maliput/maliput_py.git',                            version: 'main' }
   maliput_dragway           : { type: 'git', url: 'https://github.com/maliput/maliput_dragway.git',                       version: 'main' }
   maliput_multilane         : { type: 'git', url: 'https://github.com/maliput/maliput_multilane.git',                     version: 'main' }
+  maliput_sparse            : { type: 'git', url: 'https://github.com/maliput/maliput_sparse.git',                        version: 'main' }
+  maliput_osm               : { type: 'git', url: 'https://github.com/maliput/maliput_osm.git',                           version: 'main' }


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_osm/issues/22 and https://github.com/maliput/maliput_sparse/issues/25

## Summary

Adds maliput_sparse and maliput_osm dependencies to the maliput.repos file and CI builds.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
