### PR TITLE
Removes maliput_drake.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -7,7 +7,6 @@ repositories:
   maliput                   : { type: 'git', url: 'https://github.com/maliput/maliput.git',                               version: 'main' }
   maliput_object            : { type: 'git', url: 'https://github.com/maliput/maliput_object.git',                        version: 'main' }
   maliput_object_py         : { type: 'git', url: 'https://github.com/maliput/maliput_object_py.git',                     version: 'main' }
-  maliput_drake             : { type: 'git', url: 'https://github.com/maliput/maliput_drake.git',                         version: 'main' }
   maliput_integration       : { type: 'git', url: 'https://github.com/maliput/maliput_integration.git',                   version: 'main' }
   maliput_integration_tests : { type: 'git', url: 'https://github.com/maliput/maliput_integration_tests.git',             version: 'main' }
   maliput_malidrive         : { type: 'git', url: 'https://github.com/maliput/maliput_malidrive.git',                     version: 'main' }

--- a/maliput_full/package.xml
+++ b/maliput_full/package.xml
@@ -11,7 +11,6 @@
 
   <exec_depend>maliput</exec_depend>
   <exec_depend>maliput_dragway</exec_depend>
-  <exec_depend>maliput_drake</exec_depend>
   <exec_depend>maliput_integration</exec_depend>
   <exec_depend>maliput_malidrive</exec_depend>
   <exec_depend>maliput_multilane</exec_depend>

--- a/maliput_full/repos/foxy/maliput_full.repos
+++ b/maliput_full/repos/foxy/maliput_full.repos
@@ -1,7 +1,6 @@
 repositories:
   maliput                   : { type: 'git', url: 'https://github.com/maliput/maliput.git',                               version: 'main' }
   maliput_dragway           : { type: 'git', url: 'https://github.com/maliput/maliput_dragway.git',                       version: 'main' }
-  maliput_drake             : { type: 'git', url: 'https://github.com/maliput/maliput_drake.git',                         version: 'main' }
   maliput_integration       : { type: 'git', url: 'https://github.com/maliput/maliput_integration.git',                   version: 'main' }
   maliput_malidrive         : { type: 'git', url: 'https://github.com/maliput/maliput_malidrive.git',                     version: 'main' }
   maliput_multilane         : { type: 'git', url: 'https://github.com/maliput/maliput_multilane.git',                     version: 'main' }

--- a/repos_index/foxy/maliput.repos
+++ b/repos_index/foxy/maliput.repos
@@ -3,7 +3,6 @@ repositories:
   maliput                   : { type: 'git', url: 'https://github.com/maliput/maliput.git',                               version: 'main' }
   maliput_object            : { type: 'git', url: 'https://github.com/maliput/maliput_object.git',                        version: 'main' }
   maliput_object_py         : { type: 'git', url: 'https://github.com/maliput/maliput_object_py.git',                     version: 'main' }
-  maliput_drake             : { type: 'git', url: 'https://github.com/maliput/maliput_drake.git',                         version: 'main' }
   maliput_integration       : { type: 'git', url: 'https://github.com/maliput/maliput_integration.git',                   version: 'main' }
   maliput_integration_tests : { type: 'git', url: 'https://github.com/maliput/maliput_integration_tests.git',             version: 'main' }
   maliput_malidrive         : { type: 'git', url: 'https://github.com/maliput/maliput_malidrive.git',                     version: 'main' }

--- a/tools/run_scan_build.py
+++ b/tools/run_scan_build.py
@@ -33,7 +33,7 @@
 import os
 import sys
 
-EXTRA_EXCLUDE_ARGS = " --exclude src/pybind11 --exclude /usr/include/eigen3 --exclude src/maliput_drake --exclude /usr/include/c++ "
+EXTRA_EXCLUDE_ARGS = " --exclude /usr/include/eigen3 --exclude /usr/include/c++ "
 
 def get_package_dependencies_names(packages_up_to = None):
   '''


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_infrastructure/issues/309

:exclamation: :star2:  This PR needs to be merged in sync with others!


 - Removes maliput_drake from CI
 - Removes maliput_drake from maliput_full package.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
