### PR TITLE
Installs vcstool in the docker image.

### DIFF
--- a/wheel_generation/Dockerfile
+++ b/wheel_generation/Dockerfile
@@ -60,6 +60,11 @@ RUN source /colcon_builds/install/setup.bash
 RUN echo "source /colcon_builds/install/setup.bash" >> /root/.bashrc
 
 ##########################################################################
+# Install vcstool
+##########################################################################
+RUN /opt/_internal/cpython-3.8.18/bin/pip install vcstool
+
+##########################################################################
 # Final config
 ##########################################################################
 


### PR DESCRIPTION
# 🎉 New feature

Installs vcstool in manylinux image.

## Summary

It is required to do the branching strategy for wheel generation in CI.

## Test it
You can try the following after building the image:

```sh
[root@c37a75d043ad ws]# vcs
usage: vcs <command>

Most commands take directory arguments, recursively searching for repositories
in these directories.  If no arguments are supplied to a command, it recurses
on the current directory (inclusive) by default.

The available commands are:
   branch     Show the branches
   custom     Run a custom command
   diff       Show changes in the working tree
   export     Export the list of repositories
   import     Import the list of repositories
   log        Show commit logs
   pull       Bring changes from the repository into the working copy
   push       Push changes from the working copy to the repository
   remotes    Show the URL of the repository
   status     Show the working tree status
   validate   Validate the repository list file

See 'vcs <command> --help' for more information on a specific command.
```
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
