### PR TITLE
Fixes docker and CI after ros2 key expired.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,11 @@ jobs:
     name: Compile and test
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: ghcr.io/maliput/ci_foxy_image:latest
+      credentials:
+         username: ${{ github.actor }}
+         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - name: Install ros2-apt-source
-      shell: bash
-      run: |
-        apt install curl -y;
-        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}');
-        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb";
-        apt install /tmp/ros2-apt-source.deb;
-        apt update;
     - uses: actions/checkout@v4
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,16 @@ jobs:
     name: Compile and test
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
     steps:
+    - name: Install ros2-apt-source
+      shell: bash
+      run: |
+        apt install curl -y;
+        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}');
+        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb";
+        apt install /tmp/ros2-apt-source.deb;
+        apt update;
     - uses: actions/checkout@v4
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,8 @@ jobs:
     name: Compile and test
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:20.04
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
     steps:
-    # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
-    - uses: ros-tooling/setup-ros@v0.6
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - uses: actions/checkout@v4
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}

--- a/.github/workflows/ci_foxy_image_deploy.yml
+++ b/.github/workflows/ci_foxy_image_deploy.yml
@@ -1,0 +1,26 @@
+name: ci-foxy image deploy
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  build_and_push:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'do-ci-foxy-image-build') || github.event_name == 'workflow_dispatch'}}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Login to GitHub Container Registry
+      run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+    - name: Build and tag Docker image
+      working-directory: ci_image/
+      run: |
+        docker build -t ghcr.io/${{ github.repository_owner }}/ci_foxy_image:latest .
+
+    - name: Push Docker image to GHCR
+      run: docker push ghcr.io/${{ github.repository_owner }}/ci_foxy_image:latest

--- a/.github/workflows/maliput_full.yml
+++ b/.github/workflows/maliput_full.yml
@@ -25,8 +25,16 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
     steps:
+    - name: Install ros2-apt-source
+      shell: bash
+      run: |
+        apt install curl -y;
+        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}');
+        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb";
+        apt install /tmp/ros2-apt-source.deb;
+        apt update;
     - uses: actions/checkout@v4
     - uses: ros-tooling/action-ros-ci@v0.4
       id: action_ros_ci_step

--- a/.github/workflows/maliput_full.yml
+++ b/.github/workflows/maliput_full.yml
@@ -25,11 +25,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:20.04
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: ros-tooling/setup-ros@v0.6
-    - uses: ros-tooling/action-ros-ci@v0.3
+    - uses: ros-tooling/action-ros-ci@v0.4
       id: action_ros_ci_step
       with:
         package-name: ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/maliput_full.yml
+++ b/.github/workflows/maliput_full.yml
@@ -25,16 +25,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: ghcr.io/maliput/ci_foxy_image:latest
+      credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - name: Install ros2-apt-source
-      shell: bash
-      run: |
-        apt install curl -y;
-        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}');
-        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb";
-        apt install /tmp/ros2-apt-source.deb;
-        apt update;
     - uses: actions/checkout@v4
     - uses: ros-tooling/action-ros-ci@v0.4
       id: action_ros_ci_step

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -19,7 +19,7 @@ jobs:
     name: Compile and test with sanitizer
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
     strategy:
       matrix:
         sanitizer: [none, asan, ubsan]
@@ -35,6 +35,14 @@ jobs:
       CXX: clang++-8
       LDFLAGS: -fuse-ld=lld-8
     steps:
+    - name: Install ros2-apt-source
+      shell: bash
+      run: |
+        apt install curl -y;
+        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}');
+        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb";
+        apt install /tmp/ros2-apt-source.deb;
+        apt update;
     - uses: actions/checkout@v4
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -19,7 +19,7 @@ jobs:
     name: Compile and test with sanitizer
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:20.04
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
     strategy:
       matrix:
         sanitizer: [none, asan, ubsan]
@@ -35,10 +35,6 @@ jobs:
       CXX: clang++-8
       LDFLAGS: -fuse-ld=lld-8
     steps:
-    # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
-    - uses: ros-tooling/setup-ros@v0.6
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - uses: actions/checkout@v4
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -19,7 +19,10 @@ jobs:
     name: Compile and test with sanitizer
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: ghcr.io/maliput/ci_foxy_image:latest
+      credentials:
+         username: ${{ github.actor }}
+         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
         sanitizer: [none, asan, ubsan]
@@ -35,14 +38,6 @@ jobs:
       CXX: clang++-8
       LDFLAGS: -fuse-ld=lld-8
     steps:
-    - name: Install ros2-apt-source
-      shell: bash
-      run: |
-        apt install curl -y;
-        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}');
-        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb";
-        apt install /tmp/ros2-apt-source.deb;
-        apt update;
     - uses: actions/checkout@v4
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -18,20 +18,15 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: ghcr.io/maliput/ci_foxy_image:latest
+      credentials:
+         username: ${{ github.actor }}
+         password: ${{ secrets.GITHUB_TOKEN }}
     env:
       CC: clang-8
       CXX: clang++-8
       LDFLAGS: -fuse-ld=lld-8
     steps:
-    - name: Install ros2-apt-source
-      shell: bash
-      run: |
-        apt install curl -y;
-        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}');
-        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb";
-        apt install /tmp/ros2-apt-source.deb;
-        apt update;
     - uses: actions/checkout@v4
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -18,12 +18,20 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
     env:
       CC: clang-8
       CXX: clang++-8
       LDFLAGS: -fuse-ld=lld-8
     steps:
+    - name: Install ros2-apt-source
+      shell: bash
+      run: |
+        apt install curl -y;
+        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}');
+        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb";
+        apt install /tmp/ros2-apt-source.deb;
+        apt update;
     - uses: actions/checkout@v4
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -18,16 +18,12 @@ jobs:
     name: Static analysis
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:20.04
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-latest
     env:
       CC: clang-8
       CXX: clang++-8
       LDFLAGS: -fuse-ld=lld-8
     steps:
-    # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
-    - uses: ros-tooling/setup-ros@v0.6
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - uses: actions/checkout@v4
       with:
         path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}

--- a/ci_image/Dockerfile
+++ b/ci_image/Dockerfile
@@ -1,0 +1,63 @@
+FROM ubuntu:20.04
+
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM linux
+ENV LANG en_US.UTF-8
+ENV ROS_DISTRO=foxy
+
+##########################################################################
+# Install base system dependencies
+##########################################################################
+RUN apt update && apt install -y sudo openssh-server software-properties-common \
+   debian-keyring debian-archive-keyring apt-utils \
+   locales && \
+   rm -rf /var/lib/apt/lists/*
+RUN locale-gen en_US.UTF-8
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+
+##########################################################################
+# Install basic tools
+##########################################################################
+RUN apt-get update && apt-get install -y \
+    bash-completion \
+    build-essential \
+    git \
+    lsb-release \
+    wget \
+    curl \
+    cmake \
+    python3 \
+    python3-dev \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+##########################################################################
+# Install ros2 apt source
+##########################################################################
+
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') && \
+    curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" && \
+    apt install /tmp/ros2-apt-source.deb && \
+    apt update && \
+    rm -rf /tmp/ros2-apt-source.deb
+
+##########################################################################
+# Install utilities
+##########################################################################
+
+RUN apt install -y \
+    python3-setuptools \
+    python3-vcstool \
+    python3-rosdep \
+    python3-colcon-common-extensions \
+    ros-${ROS_DISTRO}-ament-cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+##########################################################################
+# Final config
+##########################################################################
+RUN apt update && rosdep init && rosdep update --include-eol-distros
+
+CMD ["/bin/bash"]

--- a/ci_image/Dockerfile
+++ b/ci_image/Dockerfile
@@ -52,6 +52,8 @@ RUN apt install -y \
     python3-vcstool \
     python3-rosdep \
     python3-colcon-common-extensions \
+    python3-colcon-coveragepy-result \
+    python3-colcon-lcov-result \
     ros-${ROS_DISTRO}-ament-cmake \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ci_image/README.md
+++ b/ci_image/README.md
@@ -1,0 +1,28 @@
+## CI Image
+
+### Summary
+
+A dockerfile is provided to be used for CI.
+This image simply contains:
+ - Ubuntu Focal (As BASE image)
+ - ros2-apt-source
+ - Base essentials tools
+
+### Why?
+
+Typically we should be able to rely on GH actions like:
+ - https://github.com/ros-tooling/setup-ros
+ - https://github.com/ros-tooling/action-ros-ci
+
+However, after ROS 2 key expiring during 2025/06 plus Foxy being EOL we ran out of support for foxy in these
+useful github actions.
+
+### Usage
+
+```
+docker build -t ubuntu_focal_foxy .
+```
+
+```
+docker run --rm -it ubuntu_focal_foxy bash
+```


### PR DESCRIPTION
# 🦟 Bug fix
Related to #322 
## Summary
Ros2 key expired and a new way to instal the repository is provided.
This PR updates CI and `install_prerequisites.sh` file.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
